### PR TITLE
Fix Uncaught TypeError when passing in results from document.querySel…

### DIFF
--- a/muuri.js
+++ b/muuri.js
@@ -761,7 +761,7 @@
       return [];
     }
 
-    var targetElements = [].concat(elements);
+    var targetElements = Array.isArray(elements) || isNodeList(elements) ? elements : [elements];
     var newItems = [];
 
     // Return early if there are no items.

--- a/muuri.js
+++ b/muuri.js
@@ -761,7 +761,7 @@
       return [];
     }
 
-    var targetElements = Array.isArray(elements) || isNodeList(elements) ? elements : [elements];
+    var targetElements = isNodeList(elements) ? nodeListToArray(elements) : [].concat(elements);
     var newItems = [];
 
     // Return early if there are no items.
@@ -3593,7 +3593,7 @@
   /**
    * If item is dragged into another grid, finish the migration process
    * gracefully.
-   * 
+   *
    * @public
    * @memberof ItemDrag.prototype
    * @returns {ItemDrag}


### PR DESCRIPTION
This is not a bug report, but a feature request because I'm trying to pass in a NodeList into the grid.add method instead of an array. My current workaround is to just convert the NodeList to an array via Array.from(document.querySelectorAll('.some-selector')) but I think it would be nice if the add method could also accept a NodeList.

Here's an example of the error generated when trying to pass a NodeList into grid.add: [Muuri Plunker](https://plnkr.co/edit/9MJTAN5mb1WfkpljmxZ2). If you click on the 'Add Item Array' button you will see the error in dev tools console. If you swap out the cdnjs script in index.html for the muuri-fixed.js file you can test my change. 

I ran the tests and none of them failed.