### PR TITLE
Add default safeZone value to the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1197,6 +1197,7 @@ If you want to trigger scrolling on any element during dragging you can enable a
     targets: [],
     handle: null,
     threshold: 50,
+    safeZone: 0.2,
     speed: Muuri.AutoScroller.smoothSpeed(1000, 2000, 2500),
     sortDuringScroll: true,
     smoothStop: false,


### PR DESCRIPTION
`safeZone: 0.2` is present in the full options list at [# Grid constructor](https://github.com/haltu/muuri#grid-constructor), but it is missing at [# option: dragAutoScroll](https://github.com/haltu/muuri#-option-dragautoscroll.)

This PR adds it at [# option: dragAutoScroll](https://github.com/haltu/muuri#-option-dragautoscroll.)