### PR TITLE
Fix typos in JSDoc tags (fixes #500)

### DIFF
--- a/src/Item/ItemDrag.js
+++ b/src/Item/ItemDrag.js
@@ -1175,7 +1175,6 @@ ItemDrag.prototype._onStart = function (event) {
  * Prepare item to be dragged.
  *
  * @private
- *  ItemDrag.prototype
  */
 ItemDrag.prototype._prepareStart = function () {
   if (!this._isActive) return;

--- a/src/utils/getCurrentStyles.js
+++ b/src/utils/getCurrentStyles.js
@@ -11,7 +11,7 @@ import getStyleName from './getStyleName';
  * Get current values of the provided styles definition object or array.
  *
  * @param {HTMLElement} element
- * @param {(Object|Array} styles
+ * @param {(Object|Array)} styles
  * @return {Object}
  */
 export default function getCurrentStyles(element, styles) {


### PR DESCRIPTION
Fixes #500 ([bug, minor] Found a couple typos in the JSDoc markup)