### PR TITLE
Feat - itemAnchorClick

### DIFF
--- a/src/Grid/Grid.js
+++ b/src/Grid/Grid.js
@@ -130,6 +130,7 @@ var layoutId = 0;
  * @param {String} [options.itemDraggingClass="muuri-item-dragging"]
  * @param {String} [options.itemReleasingClass="muuri-item-releasing"]
  * @param {String} [options.itemPlaceholderClass="muuri-item-placeholder"]
+ * @param {?function(Item, MouseEvent): (boolean|undefined)} [options.itemAnchorClick]
  */
 function Grid(element, options) {
   // Allow passing element as selector string
@@ -391,6 +392,11 @@ Grid.defaultOptions = {
   itemDraggingClass: 'muuri-item-dragging',
   itemReleasingClass: 'muuri-item-releasing',
   itemPlaceholderClass: 'muuri-item-placeholder',
+  /**
+   * Optional callback for anchor (<a>) item clicks. If set, called with (item, event) when a click on an <a> item would trigger navigation. If it returns false or calls event.preventDefault(), navigation is prevented.
+   * @type {?function(Item, MouseEvent): (boolean|undefined)}
+   */
+  itemAnchorClick: null,
 };
 
 /**

--- a/src/Item/ItemDrag.js
+++ b/src/Item/ItemDrag.js
@@ -680,6 +680,8 @@ ItemDrag.prototype._forceResolveStartPredicate = function (event) {
  */
 ItemDrag.prototype._finishStartPredicate = function (event) {
   var element = this._item._element;
+  var grid = this._item.getGrid();
+  var settings = grid._settings;
 
   // Check if this is a click (very subjective heuristics).
   var isClick = Math.abs(event.deltaX) < 2 && Math.abs(event.deltaY) < 2 && event.deltaTime < 200;
@@ -689,7 +691,14 @@ ItemDrag.prototype._finishStartPredicate = function (event) {
 
   // If the gesture can be interpreted as click let's try to open the element's
   // href url (if it is an anchor element).
-  if (isClick) openAnchorHref(element);
+  if (isClick) {
+    if (typeof settings.itemAnchorClick === 'function' && element.tagName.toLowerCase() === 'a') {
+      var clickEvent = event.srcEvent;
+      var result = settings.itemAnchorClick(this._item, clickEvent);
+      if (result === false || (clickEvent && clickEvent.defaultPrevented)) return;
+    }
+    openAnchorHref(element);
+  }
 };
 
 /**


### PR DESCRIPTION
Currently, Muuri always opens `<a>` hrefs when clicked - we needed a mechanism to do this conditionally. Think Jira-like kanban board where items are represented by `<a>` elements, and the elements contain a checkbox which prevents opening the href:

![image](https://github.com/user-attachments/assets/fe5db42c-812f-436e-b622-e08f3bf44d28)

To support this, a new option `itemAnchorClick` is introduced. If set, this handler enables preventing navigation. We use it like:
```js
itemAnchorClick: function(item, event) {

    // if we clicked on the checkbox, stop
    if (event.target.closest('.kanbanCardCheckbox')) {
        event.preventDefault();
        return false;
    }
    
    let id = item.getElement().getAttribute("data-el-id");
    
    // clicked on the item, navigate (Blazor)
    if (id) {
        pars.net["invokeMethodAsync"]("JsAppNavigation", id);
    }
    
    return false; // return true would result in calling "openAnchorHref" as before this PR
}
```